### PR TITLE
feat(rag): Advanced RAG — Query Translation, Multi-Query & RAG-Fusion + Docker i testovi

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ EMBEDDING_MODEL=sentence-transformers/all-MiniLM-L6-v2
 
 # Qdrant
 QDRANT_URL=http://qdrant:6333
-# QDRANT_API_KEY=     # optional if you secure Qdrant
+# QDRANT_API_KEY=     
 
 # LLM provider: openai | ollama | mock
 LLM_PROVIDER=mock
@@ -16,6 +16,6 @@ LLM_PROVIDER=mock
 # OPENAI_API_KEY=
 OPENAI_MODEL=gpt-4o-mini
 
-# Ollama (optional)
+# Ollama
 OLLAMA_BASE_URL=http://localhost:11434
 OLLAMA_MODEL=llama3.2:3b

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 
 
 # System deps (curl zbog healthcheckova i općenito, build-essential zbog uvloop itd.)
+# na kraju healcheck-ovi ipak bez curl
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential curl git \
  && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -1,60 +1,273 @@
 # Valere RAG (REST)
 
-Minimalni RAG demo: 20 Newsgroups → Qdrant (vector DB) → FastAPI REST → LLM (OpenAI/Ollama/Mock).
+Minimalni RAG demo: **20 Newsgroups → Qdrant (vector DB) → FastAPI REST → LLM (OpenAI/Ollama/Mock)**  
+Uz to: **Query Translation**, **Multi-Query** i **RAG-Fusion (RRF)**.
 
-## Quickstart
+---
+
+## Sadržaj
+- [Quickstart (Docker)](#quickstart-docker)
+- [Točan redoslijed pokretanja — terminal pipeline](#točan-redoslijed-pokretanja--terminal-pipeline)
+- [Endpoints](#endpoints)
+- [Napredni RAG (Translation / Multi-Query / Fusion)](#napredni-rag-translation--multi-query--fusion)
+- [Primjeri cURL poziva](#primjeri-curl-poziva)
+- [Bash testovi (kopiraj u .sh)](#bash-testovi-kopiraj-u-sh)
+- [Lokalno (bez Dockera)](#lokalno-bez-dockera)
+- [Konfiguracija (.env)](#konfiguracija-env)
+- [Troubleshooting](#troubleshooting)
+- [Dev notes](#dev-notes)
+
+---
+
+## Quickstart (Docker)
 
 1. Kloniraj i postavi env:
    ```bash
    cp .env.example .env
-   # (po želji) otkomentiraj LLM_PROVIDER i model, npr.:
-   # LLM_PROVIDER=ollama   # ili openai (treba API ključ)
-2. Pokreni docker stack:
-    ```bash
-    docker compose up --build -d
-3. (Opcionalno) Lokalno pokretanje umjesto Dockera:
-    ```bash
-    pip install -r requirements.txt
-    uvicorn app.main:create_app --factory --reload
-4. Ingest podataka (dataset: 20newsgroups):
-    ```bash
-    curl -X POST http://localhost:8000/ingest \
-        -H "Content-Type: application/json" \
-        -d '{"dataset":"20newsgroups","recreate":true}'
-    # odgovor: {"collection":"newsgroups","chunks_indexed": N, "dim": <stvarna dimenzija>}
-5. Postavi upit:
-    ```bash
-    curl -X POST http://localhost:8000/query \
-        -H "Content-Type: application/json" \
-        -d '{"query":"What is comp.graphics?", "k": 5}'
+   # preporučeno (Ollama u docker compose-u):
+   # LLM_PROVIDER=ollama
+   # OLLAMA_BASE_URL=http://ollama:11434
+   # OLLAMA_MODEL=llama3.2:3b
+   # LLM_TIMEOUT=300
+   ```
 
+2. Pokreni docker stack (sve servise):
+   ```bash
+   docker compose up --build -d
+   ```
 
+3. Provjere:
+   ```bash
+   curl -sS http://localhost:8000/health | jq
+   curl -sS http://localhost:6333/collections | jq
+   ```
+
+4. Ingest podataka (dataset: 20 Newsgroups):
+   ```bash
+   curl -sS -X POST http://localhost:8000/ingest      -H "Content-Type: application/json"      -d '{"dataset":"20newsgroups","recreate":true}' | jq
+   ```
+
+5. Postavi upit (baseline):
+   ```bash
+   curl -sS -X POST http://localhost:8000/query      -H "Content-Type: application/json"      -d '{"query":"What is comp.graphics?","k":5}' | jq
+   ```
+
+---
+
+## Točan redoslijed pokretanja — terminal pipeline
+
+> Ako koristiš `docker compose up -d`, Compose će pokrenuti sve servise i ovisnosti.  
+> U ručnom/Debug scenariju koristi slijed ispod:
+
+```bash
+# 1) Digni bazne servise
+docker compose up -d qdrant ollama
+
+# 2) Povuci model u docker Ollami (one-shot init servis ili ručno)
+docker compose up -d ollama-init
+# ili ručno:
+# docker compose exec ollama ollama pull llama3.2:3b
+
+# 3) Provjere (Ollama + Qdrant)
+docker compose ps
+curl -sS http://localhost:6333/collections | jq
+docker compose exec -T ollama ollama list
+# iz API kontejnera provjeri pristup Ollami (dobit ćeš listu modela)
+docker compose exec -T api curl -sS http://ollama:11434/api/tags | jq || true
+
+# 4) Digni API
+docker compose up -d api
+curl -sS http://localhost:8000/health | jq
+
+# 5) Ingest (prvi put ili nakon čišćenja volumena/promjene embeddera)
+curl -sS -X POST http://localhost:8000/ingest   -H "Content-Type: application/json"   -d '{"dataset":"20newsgroups","recreate":true}' | jq
+
+# 6) Upiti (baseline i advanced)
+curl -sS -X POST http://localhost:8000/query   -H "Content-Type: application/json"   -d '{"query":"What is comp.graphics?","k":5}' | jq
+
+curl -sS -X POST http://localhost:8000/query   -H "Content-Type: application/json"   -d '{"query":"Što je X Window System?","k":5,"mode":"fusion","n_queries":4}' | jq
+```
+
+---
 
 ## Endpoints
-- `GET /health` → `{ "status": "ok", "collection": "..." }`
-- `GET /collections`→ `{ "collections": [...] }`
+
+- `GET /health` → `{ "status": "ok", "collection": "<ime_kolekcije>" }`
+- `GET /collections` → `{ "collections": [...] }`
 - `DELETE /collections/{name}`
-- `POST /ingest`
-    Body: `{"dataset":"20newsgroups","recreate":true}`
-    Response: `{"collection":"newsgroups","chunks_indexed":N,"dim":<embedding-dim>}`
-        Dimenzija se izračuna iz aktivnog embedding modela
-- `POST /query`
-    Body: `{"query":"...", "k":5}`
-    Response:
+- `POST /ingest`  
+  **Body**: `{"dataset":"20newsgroups","recreate":true}`  
+  **Response**: `{"collection":"newsgroups","chunks_indexed":N,"dim":<embedding-dim>}`
+- `POST /query`  
+  **Body (minimalno)**: `{"query":"...", "k":5}`  
+  **Napredne opcije**: `mode`, `n_queries`, `translate` (vidi dolje)
 
-        {
-        "answer": "string",
-        "sources": [
-            {"id":"...", "score":0.0, "target_name":"...", "metadata": {...}, "content":"..."}
-        ],
-        "provider":"openai|ollama|mock",
-        "model":"gpt-4o-mini|llama3.2:3b|mock",
-        "latency_ms": 123,
-        "prompt_tokens": 123,
-        "completion_tokens": 45
-        }
+---
+
+## Napredni RAG (Translation / Multi-Query / Fusion)
+
+Dostupno preko `POST /query`:
+
+- `mode`: `"simple" | "multi" | "fusion"`
+  - **multi**: LLM generira više semantički različitih upita i **spaja** rezultate (union + dedupe).
+  - **fusion**: koristi **Reciprocal Rank Fusion (RRF)** za ujedinjavanje rangova više lista.
+- `n_queries`: broj alternativnih upita (default 4 u postavkama).
+- `translate`: `true/false` – forsira prijevod upita na engleski za retrieval.  
+  Ako embedder nije multilingual, prijevod se aktivira automatski (osim ako `translate:false`).
+
+**Primjer `meta`:**
+```json
+{
+  "provider":"ollama",
+  "model":"llama3.2:3b",
+  "latency_ms": 38446,
+  "translated": true,
+  "mode": "fusion",
+  "n_queries": 4,
+  "rrf_k": 60,
+  "pipeline_ms": 54985
+}
+```
+
+---
+
+## Primjeri cURL poziva
+
+**Baseline:**
+```bash
+curl -sS -X POST http://localhost:8000/query   -H "Content-Type: application/json"   -d '{"query":"What is comp.graphics?","k":5}' | jq
+```
+
+**Multi-Query:**
+```bash
+curl -sS -X POST http://localhost:8000/query   -H "Content-Type: application/json"   -d '{"query":"Who is the CEO of OpenAI?","k":5,"mode":"multi","n_queries":4}' | jq
+```
+
+**RAG-Fusion (RRF):**
+```bash
+curl -sS -X POST http://localhost:8000/query   -H "Content-Type: application/json"   -d '{"query":"Who is the CEO of OpenAI?","k":5,"mode":"fusion","n_queries":4}' | jq
+```
+
+**Query Translation (force):**
+```bash
+curl -sS -X POST http://localhost:8000/query   -H "Content-Type: application/json"   -d '{"query":"Ko je izvršni direktor OpenAI?","k":5,"mode":"fusion","translate":true}' | jq ".meta"
+```
+
+---
+
+## Bash testovi (kopiraj u .sh)
+
+> Ove skripte možeš spremiti u `bash-tests/` i pokrenuti:  
+> `chmod +x bash-tests/*.sh && bash bash-tests/test_multi_query.sh`
+
+**`bash-tests/test_health_ingest.sh`**
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+API="${API:-http://localhost:8000}"
+
+echo "Checking API health..."
+curl -fsS "$API/health" | jq -e '.status=="ok"' >/dev/null
+
+echo "Ingesting dataset (20newsgroups)…"
+curl -fsS -X POST "$API/ingest" -H "Content-Type: application/json"   -d '{"dataset":"20newsgroups","recreate":false}' | jq -e '.collection=="newsgroups"' >/dev/null
+
+echo "OK ✅"
+```
+
+**`bash-tests/test_multi_query.sh`**
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+API="${API:-http://localhost:8000}"
+
+BODY='{"query":"Who is the CEO of OpenAI?","k":5,"mode":"multi","n_queries":4}'
+echo "Testing Multi-Query..."
+resp="$(curl -fsS -X POST "$API/query" -H "Content-Type: application/json" -d "$BODY")"
+echo "$resp" | jq . >/dev/null
+
+mode="$(echo "$resp" | jq -r '.meta.mode')"
+nq="$(echo "$resp" | jq -r '.meta.n_queries')"
+
+[[ "$mode" == "multi" ]] || { echo "Expected mode=multi, got: $mode"; exit 1; }
+[[ "$nq" -ge 2 ]] || { echo "Expected n_queries>=2, got: $nq"; exit 1; }
+
+echo "Multi-Query OK ✅"
+```
+
+**`bash-tests/test_fusion.sh`**
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+API="${API:-http://localhost:8000}"
+
+BODY='{"query":"Who is the CEO of OpenAI?","k":5,"mode":"fusion","n_queries":4}'
+echo "Testing RAG-Fusion (RRF)..."
+resp="$(curl -fsS -X POST "$API/query" -H "Content-Type: application/json" -d "$BODY")"
+echo "$resp" | jq . >/dev/null
+
+mode="$(echo "$resp" | jq -r '.meta.mode')"
+rrf="$(echo "$resp" | jq -r '.meta.rrf_k')"
+
+[[ "$mode" == "fusion" ]] || { echo "Expected mode=fusion, got: $mode"; exit 1; }
+[[ "$rrf" != "null" ]] || { echo "Expected rrf_k to be set"; exit 1; }
+
+echo "Fusion OK ✅"
+```
+
+---
+
+## Lokalno (bez Dockera)
+
+```bash
+pip install -r requirements.txt
+uvicorn app.main:create_app --factory --reload
+
+# u drugom terminalu:
+curl -sS http://localhost:8000/health | jq
+```
+
+---
+
+## Konfiguracija (.env)
+
+```dotenv
+HOST=0.0.0.0
+PORT=8000
+
+EMBEDDING_MODEL=sentence-transformers/paraphrase-MiniLM-L3-v2
+
+QDRANT_URL=http://qdrant:6333
+
+LLM_PROVIDER=ollama
+LLM_TIMEOUT=300
+
+# OPENAI_API_KEY=...
+OPENAI_MODEL=gpt-4o-mini
+
+OLLAMA_BASE_URL=http://ollama:11434
+OLLAMA_MODEL=llama3.2:3b
+```
+
+> Ako koristiš **host** Ollama (izvan Dockera):  
+> `OLLAMA_BASE_URL=http://host.docker.internal:11434`
+
+---
+
+## Troubleshooting
+
+- **`/api/tags` prazan** → model nije povučen u **docker** Ollami.  
+  `docker compose exec ollama ollama pull llama3.2:3b`
+- **Prvi upit traje dugo** → hladni start; koristi `LLM_TIMEOUT=300` i `OLLAMA_KEEP_ALIVE=30m` (compose env u `ollama` servisu).
+- **Qdrant healthcheck crveni** → možeš maknuti healthcheck; app ionako čeka Qdrant na startu.
+- **Nema odgovora na temu** → 20NG nema taj sadržaj; dodaj vlastite dokumente ili implementiraj `/ingest_texts` endpoint za ad-hoc tekstove.
+
+---
+
 ## Dev notes
-- Embeddings: all-MiniLM-L6-v2 (dim=384)
-- Vector DB: Qdrant (cosine)
-- LLM: OpenAI / Ollama / Mock (fallback)
 
+- Embeddings: MiniLM (paraphrase), dimenzija se detektira runtime.
+- Vector DB: Qdrant (cosine).
+- LLM: OpenAI / Ollama / Mock.
+- Advanced RAG: Query Translation (auto/force), Multi-Query, RAG-Fusion (RRF).
+- LangChain adapteri: **langchain-huggingface** (embedding) i **langchain-qdrant** (vectorstore).

--- a/app/api.py
+++ b/app/api.py
@@ -1,14 +1,15 @@
 
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
-
 from .config import settings
 from .models import IngestRequest, IngestResponse, QueryRequest, QueryResponse, CollectionsResponse
-
 from .errors import register_exception_handlers, ProviderError, IngestionError, VectorStoreError
+from .models import IngestRequest, IngestResponse, QueryRequest, QueryResponse, CollectionsResponse, SourceDoc, MetaInfo
 
 # koristimo v2 chain
 from .rag import answer_with_rag_v2
+# napredni RAG (translation + multi-query + fusion)
+from .rag_advanced import answer_advanced
 from .vectorstore import (
     get_or_create_vectorstore,
     make_qdrant_client,
@@ -69,13 +70,35 @@ def build_app() -> FastAPI:
         return IngestResponse(collection=settings.qdrant_collection, chunks_indexed=n, dim=emb.dim())
 
     @app.post("/query", response_model=QueryResponse)
-    def query(req: QueryRequest):
+    def query_endpoint(req: QueryRequest):
         if not req.query.strip():
             raise HTTPException(400, "Empty query.")
 
         k = req.k or 5
+        # Ako klijent pošalje napredne opcije -> koristi advanced,
+        # inače fallback na postojeći v2 chain
+        use_adv = bool(getattr(req, "mode", None)) or (getattr(req, "translate", None) is not None)
+
         try:
-            answer, docs, meta = answer_with_rag_v2(req.query, k=k)
+            if use_adv:
+                mode = (
+                    req.mode
+                    or ("fusion" if getattr(settings, "enable_rag_fusion", True)
+                        else "multi" if getattr(settings, "enable_multi_query", True)
+                        else "simple")
+                )
+
+                res = answer_advanced(
+                    req.query,
+                    k=k,
+                    translate=getattr(req, "translate", None),
+                    mode=mode,
+                    n_queries=getattr(req, "n_queries", None) or getattr(settings, "multi_query_n", 4),
+                    k_smooth=getattr(settings, "rrf_k_smooth", 60),
+                )
+                answer, docs, meta = res.answer, res.docs, res.meta
+            else:
+                answer, docs, meta = answer_with_rag_v2(req.query, k=k)
         except ProviderError:
             raise
         except VectorStoreError:
@@ -86,11 +109,7 @@ def build_app() -> FastAPI:
         return QueryResponse(
             answer=answer,
             sources=as_sourcedocs(docs),
-            provider=meta.get("provider"),
-            model=meta.get("model"),
-            latency_ms=meta.get("latency_ms"),
-            prompt_tokens=meta.get("prompt_tokens"),
-            completion_tokens=meta.get("completion_tokens"),
+            meta=MetaInfo(**(meta or {})),
         )
 
     return app

--- a/app/config.py
+++ b/app/config.py
@@ -15,16 +15,55 @@ class Settings(BaseSettings):
     qdrant_collection: str = Field(default="newsgroups")
 
     # LLM provider: "openai" | "ollama" | "mock"
-    llm_provider: str = Field(default="mock")
+    llm_provider: str = Field(default="ollama")
     openai_api_key: str | None = None
     openai_model: str = Field(default="gpt-4o-mini")
     ollama_base_url: str = Field(default="http://localhost:11434")
-    ollama_model: str = Field(default="llama3.1:8b")
+    ollama_model: str = Field(default="llama3.2:3b")
 
     # Ingestion defaults
     chunk_size: int = Field(default=800)
     chunk_overlap: int = Field(default=100)
 
+     # -------------------------
+    # Advanced RAG knobs  (NOVO)
+    # -------------------------
+    # Globalne postavke koje koristi napredni pipeline ako klijent ne pošalje per-request opcije
+    enable_query_translation: bool = Field(
+        default=True,
+        description="Ako je embedding ENG-only, drži uključeno; za multilingual možeš ugasiti."
+    )
+    enable_multi_query: bool = Field(default=True)
+    enable_rag_fusion: bool = Field(default=True)
+    multi_query_n: int = Field(default=4)
+    rrf_k_smooth: int = Field(default=60)
+
+    # LLM timeout (u sekundama)
+    llm_timeout: int = Field(default=300, description="LLM HTTP timeout in seconds")
+    # Pydantic v2 settings
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
+    # -------------------------
+    # Alias/proxy svojstva  (NOVO)
+    # -------------------------
+    @property
+    def llm_model(self) -> str:
+        """
+        Jedinstvena točka istine za naziv chat modela,
+        bez obzira je li provider 'openai' ili 'ollama'.
+        """
+        if self.llm_provider == "openai":
+            return self.openai_model
+        if self.llm_provider == "ollama":
+            return self.ollama_model
+        # mock ili drugi – vrati nešto benigno
+        return "mock"
+
+    @property
+    def ollama_url(self) -> str:
+        """
+        Udoban alias; neka llm.py koristi ovo za base URL.
+        """
+        return self.ollama_base_url
 
 settings = Settings()

--- a/app/llm.py
+++ b/app/llm.py
@@ -1,43 +1,50 @@
-
 from time import perf_counter
 from typing import List
 from .config import settings
 from .interfaces import ChatMessage, ChatResult, SupportsChat
+from .errors import ProviderError  # ako već postoji u tvojem projektu
 
 
 class OpenAIChat:
     def __init__(self):
         from langchain_openai import ChatOpenAI
 
+        if not settings.openai_api_key:
+            raise ProviderError("OPENAI_API_KEY is not set")
+
         self.llm = ChatOpenAI(
-            model=settings.openai_model,
+            model=settings.llm_model,  # alias iz config.py
             api_key=settings.openai_api_key,
             temperature=0.2,
-            timeout=60,
+            timeout=settings.llm_timeout,  
             max_retries=1,
         )
 
     def invoke(self, messages: List[ChatMessage]) -> ChatResult:
         from langchain.schema import HumanMessage, SystemMessage, AIMessage
 
-        
         lmsgs = []
         for m in messages:
             if m["role"] == "system":
                 lmsgs.append(SystemMessage(content=m["content"]))
-
             elif m["role"] == "assistant":
                 lmsgs.append(AIMessage(content=m["content"]))
             else:
                 lmsgs.append(HumanMessage(content=m["content"]))
+
         t0 = perf_counter()
-        out = self.llm.invoke(lmsgs)
+        try:
+            out = self.llm.invoke(lmsgs)
+        except Exception as e:
+            raise ProviderError(str(e))
         dt = int((perf_counter() - t0) * 1000)
-        meta = getattr(out, "response_metadata", {})
+
+        meta = getattr(out, "response_metadata", {}) or {}
         usage = meta.get("token_usage", {}) or {}
+
         return ChatResult(
             content=out.content,
-            model=meta.get("model_name", settings.openai_model),
+            model=meta.get("model_name", settings.llm_model),
             provider="openai",
             finish_reason=meta.get("finish_reason"),
             prompt_tokens=usage.get("prompt_tokens"),
@@ -46,22 +53,29 @@ class OpenAIChat:
         )
 
     def provider(self) -> str: return "openai"
-    def model(self) -> str | None: return settings.openai_model
+    def model(self) -> str | None: return settings.llm_model
 
 
 class OllamaChat:
     def __init__(self):
         from langchain_community.chat_models import ChatOllama
-        self.llm = ChatOllama(
-            base_url=settings.ollama_base_url,
-            model=settings.ollama_model,
-            temperature=0.2,
-
-            timeout=60,
-        )
+        try:
+            self.llm = ChatOllama(
+                base_url=settings.ollama_url,
+                model=settings.llm_model,
+                temperature=0.2,
+                client_kwargs={"timeout": settings.llm_timeout},  
+            )
+        except TypeError:
+            # fallback za starije verzije
+            self.llm = ChatOllama(
+                base_url=settings.ollama_url,
+                model=settings.llm_model,
+                temperature=0.2,
+                timeout=settings.llm_timeout,  
+            )
 
     def invoke(self, messages: List[ChatMessage]) -> ChatResult:
-        # ChatOllama može i dict poruke, ali radi konzistentnosti koristimo LC message objekte
         from langchain.schema import HumanMessage, SystemMessage, AIMessage
         lmsgs = []
         for m in messages:
@@ -71,19 +85,26 @@ class OllamaChat:
                 lmsgs.append(AIMessage(content=m["content"]))
             else:
                 lmsgs.append(HumanMessage(content=m["content"]))
+
         t0 = perf_counter()
-        out = self.llm.invoke(lmsgs)
+        try:
+            out = self.llm.invoke(lmsgs)
+        except Exception as e:
+            from .errors import ProviderError
+            raise ProviderError(str(e))
         dt = int((perf_counter() - t0) * 1000)
+
         text = getattr(out, "content", str(out))
         return ChatResult(
             content=text,
-            model=settings.ollama_model,
+            model=settings.llm_model,
             provider="ollama",
             latency_ms=dt,
         )
 
     def provider(self) -> str: return "ollama"
-    def model(self) -> str | None: return settings.ollama_model
+    def model(self) -> str | None: return settings.llm_model
+
 
 class MockChat:
     def invoke(self, messages: List[ChatMessage]) -> ChatResult:
@@ -100,9 +121,10 @@ class MockChat:
     def provider(self) -> str: return "mock"
     def model(self) -> str | None: return "mock"
 
+
 def make_chat() -> SupportsChat:
-    prov = (settings.llm_provider or "mock").lower()    
-    if prov == "openai" and settings.openai_api_key:
+    prov = (settings.llm_provider or "mock").lower()
+    if prov == "openai":
         return OpenAIChat()
     if prov == "ollama":
         return OllamaChat()

--- a/app/main.py
+++ b/app/main.py
@@ -1,23 +1,62 @@
-
+# app/main.py
+import time
 import uvicorn
 from .config import settings
 from .api import build_app
 
+
+def _wait_for_qdrant(timeout: int = 120, interval: float = 2.0) -> bool:
+    """Čeka da se Qdrant digne tako da periodički zove get_collections()."""
+    from .vectorstore import make_qdrant_client
+    start = time.perf_counter()
+    client = make_qdrant_client()
+    while True:
+        try:
+            client.get_collections()
+            return True
+        except Exception:
+            if time.perf_counter() - start > timeout:
+                return False
+            time.sleep(interval)
+
+
+def _warmup_ollama() -> None:
+    """
+    Trigerira mali chat poziv kako bi Ollama model (npr. llama3.2:3b)
+    bio učitan u memoriju prije prvog korisničkog upita.
+    """
+    try:
+        from .llm import make_chat
+        chat = make_chat()
+        # kratki prompt — dovoljan da natjera load modela (poštuje tvoj llm_timeout)
+        chat.invoke([{"role": "user", "content": "OK"}])
+    except Exception:
+        # ne ruši servis ako warmup ne uspije (npr. Ollama se još diže)
+        pass
+
+
 def create_app():
     app = build_app()
 
-    
+    # Pri startu: pričekaj Qdrant, pripremi embedding/vectorstore, pa ugrij LLM
     try:
-        from .vectorstore import get_embedding_service, get_or_create_vectorstore
-        _emb = get_embedding_service()
-        _ = get_or_create_vectorstore(settings.qdrant_collection, recreate=False)
-        
+        ok = _wait_for_qdrant(timeout=120, interval=2)
+        if ok:
+            from .vectorstore import get_embedding_service, get_or_create_vectorstore
+            _ = get_embedding_service()  # warm-up HF embeddera
+            _ = get_or_create_vectorstore(settings.qdrant_collection, recreate=False)
     except Exception:
-        
+        # ne ruši servis; endpointi će kasnije pokušati ponovno
+        pass
+
+    # LLM warm-up (odvojeno od Qdrant-a; nema ovisnosti)
+    try:
+        _warmup_ollama()
+    except Exception:
         pass
 
     return app
 
+
 if __name__ == "__main__":
     uvicorn.run(create_app(), host=settings.host, port=settings.port)
-

--- a/app/models.py
+++ b/app/models.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
 from pydantic import BaseModel, Field
 from typing import List, Optional, Any, Dict
+
 
 class IngestRequest(BaseModel):
     dataset: str = Field(default="20newsgroups", description="Currently supported: 20newsgroups")
@@ -9,7 +11,9 @@ class IngestRequest(BaseModel):
 
 class SourceDoc(BaseModel):
     id: str
-    metadata: Dict[str, Any]
+    score: float | None = None
+    target_name: str | None = None
+    metadata: Dict[str, Any] = Field(default_factory=dict)
     content: str
 
 class IngestResponse(BaseModel):
@@ -21,9 +25,45 @@ class QueryRequest(BaseModel):
     query: str
     k: int = 5
 
+    # Napredne opcije (opcionalno, unatrag kompatibilno)
+    mode: Optional[str] = Field(
+        default=None, description="simple | multi | fusion"
+    )
+    translate: Optional[bool] = Field(
+        default=None, description="Force translate to English for retrieval (otherwise auto)"
+    )
+    n_queries: Optional[int] = Field(
+        default=None, ge=1, le=10, description="Number of alternate queries for multi/fusion"
+    )
+
+class MetaInfo(BaseModel):
+    """
+    Struktuirani meta podaci o izvodenju upita / LLM-u / pipelineu.
+    Dozvoljavamo dodatna polja (extra='allow') za buduca prosirenja.
+    """
+    provider: Optional[str] = None
+    model: Optional[str] = None
+    latency_ms: Optional[int] = None
+    prompt_tokens: Optional[int] = None
+    completion_tokens: Optional[int] = None
+
+    # Napredno (ako koristis translation/multi/fusion)
+    translated: Optional[bool] = None
+    mode: Optional[str] = None
+    n_queries: Optional[int] = None
+    rrf_k: Optional[int] = None
+
+    # Ukupno vrijeme cijevi (ako ga saljes)
+    pipeline_ms: Optional[int] = None
+
+    class Config:
+        extra = "allow"  # dopusti npr. dodatne kljuceve iz providera
+
 class QueryResponse(BaseModel):
     answer: str
     sources: List[SourceDoc]
+    meta: Optional[MetaInfo] = None
+
 
 class CollectionsResponse(BaseModel):
     collections: List[str]

--- a/app/rag.py
+++ b/app/rag.py
@@ -95,8 +95,8 @@ def _call_llm_from_prompt(messages: List[Dict[str, Any]]):
     except Exception as e:
         from .errors import ProviderError
         raise ProviderError(str(e))
-    #  make_chat.invoke expects a list of dicts like {"role": "...", "content": "..."}
-    return chat.invoke(messages)
+        #  make_chat.invoke expects a list of dicts like {"role": "...", "content": "..."}
+    
 
 def _add_context(inp: Dict[str, Any]) -> Dict[str, Any]:
     """

--- a/app/rag_advanced.py
+++ b/app/rag_advanced.py
@@ -1,0 +1,216 @@
+# app/rag_advanced.py
+from __future__ import annotations
+from dataclasses import dataclass
+from time import perf_counter
+from typing import List, Dict, Any, Tuple, Union
+
+from langchain.schema import Document
+from langchain.load import dumps, loads
+
+from .config import settings
+from .vectorstore import get_or_create_vectorstore
+from .llm import make_chat
+
+# -------------------------
+# Helpers
+# -------------------------
+
+def _is_english_only_embeddings(model_name: str) -> bool:
+    name = (model_name or "").lower()
+    multilingual_markers = [
+        "multilingual", "paraphrase-multilingual", "labse", "xlm",
+        "laser", "use-multilingual", "distiluse", "e5-multilingual"
+    ]
+    return not any(m in name for m in multilingual_markers)
+
+def _res_content(res: Any) -> str:
+    """
+    Ekstrakcija teksta iz raznih povrata Chat sloja.
+    Podržava: string, objekt s .content, dict s ['content'].
+    """
+    if res is None:
+        return ""
+    if isinstance(res, str):
+        return res
+    if hasattr(res, "content"):
+        return getattr(res, "content") or ""
+    if isinstance(res, dict):
+        return str(res.get("content", ""))
+    return str(res)
+
+def _res_meta(res: Any) -> Dict[str, Any]:
+    meta = {}
+    for k in ("provider", "model", "latency_ms", "prompt_tokens", "completion_tokens"):
+        if hasattr(res, k):
+            meta[k] = getattr(res, k)
+        elif isinstance(res, dict) and k in res:
+            meta[k] = res[k]
+    return meta
+
+def translate_query_if_needed(query: str, force: bool | None = None) -> Tuple[str, Dict[str, Any]]:
+    """
+    Prevede korisnički upit na engleski za retrieval ako:
+      - embedding model nije multilingual ili
+      - force=True.
+    Vraća (možda prevedeni upit, meta).
+    """
+    if force is False:
+        return query, {"translated": False}
+    
+    if force is None and getattr(settings, "enable_query_translation", True) is False:
+        return query, {"translated": False}
+
+    if _is_english_only_embeddings(getattr(settings, "embedding_model", "")) or (force is True):
+        chat = make_chat()
+        # Ako je provider mock, preskoči
+        if hasattr(chat, "provider") and callable(chat.provider) and chat.provider() == "mock":
+            return query, {"translated": False, "provider": "mock"}
+
+        prompt = (
+            "Translate the following search query into **English** for semantic retrieval. "
+            "Keep named entities in original form if they are proper nouns. "
+            "Return ONLY the translated query; no quotes or explanations.\n\n"
+            f"Query: {query}"
+        )
+        res = chat.invoke([{"role": "user", "content": prompt}])
+        translated = _res_content(res).strip()
+        if not translated:
+            translated = query
+        meta = {"translated": translated != query} | _res_meta(res)
+        return translated, meta
+
+    return query, {"translated": False}
+
+def generate_multi_queries(seed_query: str, n: int = 3) -> Tuple[List[str], Dict[str, Any]]:
+    """
+    LLM generira N alternativnih, semantički različitih upita (uklj. original).
+    Ako je provider 'mock' ili n<=1, vraća samo original.
+    """
+    chat = make_chat()
+    if hasattr(chat, "provider") and callable(chat.provider) and chat.provider() == "mock":
+        return [seed_query], {"provider": "mock"}
+    if n <= 1:
+        return [seed_query], {}
+
+    prompt = (
+        "Generate {n} diverse, semantically different search queries that would retrieve the "
+        "same information as the original. Keep them concise. One per line. "
+        "Do NOT number the lines.\n\n"
+        f"Original query: {seed_query}\n\n"
+        "Queries:"
+    ).format(n=n)
+    res = chat.invoke([{"role": "user", "content": prompt}])
+    lines = [ln.strip(" •-\t") for ln in _res_content(res).splitlines() if ln.strip()]
+    uniq, seen = [], set()
+    for q in lines:
+        key = q.lower()
+        if q and key not in seen:
+            uniq.append(q)
+            seen.add(key)
+    if seed_query.lower() not in seen:
+        uniq.insert(0, seed_query)
+    uniq = uniq[:max(1, n)]
+    return uniq, {"count": len(uniq)} | _res_meta(res)
+
+def reciprocal_rank_fusion(per_query_ranked_docs: List[List[Document]], k_smooth: int = 60) -> List[Tuple[Document, float]]:
+    """
+    Reciprocal Rank Fusion: score += 1 / (rank + 1 + k_smooth)
+    Vraća listu (Document, fused_score) sortiranu silazno.
+    """
+    fused: Dict[str, float] = {}
+    for docs in per_query_ranked_docs:
+        for rank, doc in enumerate(docs):
+            key = dumps(doc)  # stabilan ključ preko JSON serializacije LC Document
+            fused[key] = fused.get(key, 0.0) + 1.0 / (rank + 1 + k_smooth)
+    ranked = sorted(fused.items(), key=lambda kv: kv[1], reverse=True)
+    return [(loads(k), score) for k, score in ranked]
+
+def _format_context(docs: List[Document]) -> str:
+    chunks = []
+    for i, d in enumerate(docs, 1):
+        meta = d.metadata or {}
+        src = meta.get("source") or meta.get("doc_id") or meta.get("id") or f"doc-{i}"
+        chunks.append(f"[{i}] ({src})\n{d.page_content}")
+    return "\n\n".join(chunks)
+
+# -------------------------
+# Public entry point
+# -------------------------
+
+@dataclass
+class AdvancedRAGResult:
+    answer: str
+    docs: List[Document]
+    meta: Dict[str, Any]
+
+def answer_advanced(
+    question: str,
+    *,
+    k: int = 5,
+    translate: bool | None = None,
+    mode: str = "simple",            # 'simple' | 'multi' | 'fusion'
+    n_queries: int = 4,
+    k_smooth: int = 60,
+) -> AdvancedRAGResult:
+
+    t0 = perf_counter()
+    vs = get_or_create_vectorstore(getattr(settings, "qdrant_collection", "default"))
+    retriever = vs.as_retriever(search_kwargs={"k": k})
+
+    # 1) Query translation (ako treba)
+    q_translated, tr_meta = translate_query_if_needed(question, force=translate)
+
+    # 2) Multi-query (opcionalno)
+    queries = [q_translated]
+    multi_meta: Dict[str, Any] = {}
+    if mode in ("multi", "fusion"):
+        queries, multi_meta = generate_multi_queries(q_translated, n=n_queries)
+
+    # 3) Retrieval
+    per_query_docs: List[List[Document]] = []
+    for q in queries:
+        try:
+            docs = retriever.invoke(q)
+        except Exception:
+            docs = retriever.get_relevant_documents(q)  # starije LC verzije
+        for idx, d in enumerate(docs):
+            d.metadata = (d.metadata or {}) | {"_rank": idx}
+        per_query_docs.append(docs)
+
+    # 4) Spajanje lista
+    if mode == "fusion":
+        fused = reciprocal_rank_fusion(per_query_docs, k_smooth=k_smooth)
+        used_docs = [d for d, _ in fused][:k]
+        rerank_meta = {"rrf_k": k_smooth}
+    elif mode == "multi":
+        seen, tmp = set(), []
+        for docs in per_query_docs:
+            for d in docs:
+                key = dumps(d)
+                if key not in seen:
+                    tmp.append(d)
+                    seen.add(key)
+        used_docs = tmp[:k]
+        rerank_meta = {}
+    else:
+        used_docs = per_query_docs[0][:k] if per_query_docs else []
+        rerank_meta = {}
+
+    # 5) Sinteza (odgovor na jeziku pitanja)
+    chat = make_chat()
+    system = "You are a helpful assistant. Use ONLY the provided context. If answer is not in context, say you don't know."
+    ctx = _format_context(used_docs)
+    user = f"Question:\n{question}\n\nContext:\n{ctx}\n\nAnswer in the same language as the question."
+
+    out = chat.invoke([{"role": "system", "content": system}, {"role": "user", "content": user}])
+    answer = _res_content(out)
+
+    meta: Dict[str, Any] = {
+        "translated": tr_meta.get("translated"),
+        "mode": mode,
+        "n_queries": len(queries),
+        **_res_meta(out),
+        **rerank_meta,
+    }
+    meta["pipeline_ms"] = int((perf_counter() - t0) * 1000)
+    return AdvancedRAGResult(answer=answer, docs=used_docs, meta=meta)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,18 @@
-version: "3.9"
 services:
   api:
     build: .
     container_name: valere-rag-api
-    env_file: 
+    env_file:
       - .env
     ports:
       - "8000:8000"
     depends_on:
       - qdrant
+      - ollama-init
     volumes:
       - ./data:/app/data
       - ./app:/app/app
+      - ./tests:/app/tests
 
   qdrant:
     image: qdrant/qdrant:v1.8.4
@@ -20,9 +21,8 @@ services:
       - "6333:6333"
     volumes:
       - qdrant_storage:/qdrant/storage
-
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:6333/readyz"]
+      test: ["CMD-SHELL", "wget -qO- http://localhost:6333/readyz >/dev/null 2>&1 || curl -sf http://localhost:6333/readyz >/dev/null 2>&1 || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 10
@@ -30,16 +30,40 @@ services:
   ollama:
     image: ollama/ollama:latest
     container_name: ollama
-    # (nema ports — koristimo je samo unutar docker mreže)
     volumes:
       - ollama:/root/.ollama
+    environment:
+      - OLLAMA_KEEP_ALIVE=30m   
+      - OLLAMA_NUM_PARALLEL=1
+    # healthcheck bez curl-a 
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:11434/api/tags"]
+      test: ["CMD", "ollama", "list"]
       interval: 10s
       timeout: 5s
-      retries: 20
+      retries: 30
+      start_period: 20s
 
+  ollama-init:
+    image: ollama/ollama:latest
+    container_name: ollama-init
+    environment:
+      - OLLAMA_HOST=http://ollama:11434     # klijent u initu neka cilja server u "ollama" servisu
+      - OLLAMA_MODEL=${OLLAMA_MODEL:-llama3.2:3b}
+    depends_on:
+      ollama:
+        condition: service_healthy
+    entrypoint: ["sh","-lc"]
+    command: |
+      echo "Waiting for ollama server..."
+      until ollama list >/dev/null 2>&1; do sleep 2; done
+      echo "Pulling model: ${OLLAMA_MODEL:-llama3.2:3b}"
+      ollama pull "${OLLAMA_MODEL:-llama3.2:3b}"
+    volumes:
+      - ollama:/root/.ollama
+    restart: "no"
 
 volumes:
   qdrant_storage:
+    name: valere-qdrant
   ollama:
+    name: valere-ollama

--- a/tests/test_api_smoke.py
+++ b/tests/test_api_smoke.py
@@ -1,0 +1,27 @@
+# tests/test_api_smoke.py
+import types
+from fastapi.testclient import TestClient
+from app.api import build_app
+
+def test_query_baseline(monkeypatch):
+    from app import rag
+    monkeypatch.setattr(rag, "answer_with_rag_v2", lambda q, k=5: ("A", [], {"provider":"mock","model":"mock","latency_ms":1}))
+    app = build_app()
+    client = TestClient(app)
+    resp = client.post("/query", json={"query":"hello","k":2})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["answer"] == "A"
+    assert "meta" in data
+
+def test_query_advanced(monkeypatch):
+    from app import rag_advanced as adv
+    fake = types.SimpleNamespace(answer="B", docs=[], meta={"mode":"fusion"})
+    monkeypatch.setattr(adv, "answer_advanced", lambda *a, **k: fake)
+    app = build_app()
+    client = TestClient(app)
+    resp = client.post("/query", json={"query":"hi","k":2,"mode":"fusion","n_queries":3})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["answer"] == "B"
+    assert data["meta"]["mode"] == "fusion"

--- a/tests/test_rag_advanced_unit.py
+++ b/tests/test_rag_advanced_unit.py
@@ -1,0 +1,76 @@
+# tests/test_rag_advanced_unit.py
+import types
+import builtins
+import pytest
+
+from app import rag_advanced as adv
+from langchain.schema import Document
+
+class DummyChat:
+    def __init__(self, responses):
+        self._responses = responses
+        self._i = 0
+    def provider(self): return "mock"
+    def invoke(self, messages):
+        # vrati sljedeći odgovor (ili zadnji)
+        text = self._responses[min(self._i, len(self._responses)-1)]
+        self._i += 1
+        return types.SimpleNamespace(content=text, provider="mock", model="mock", latency_ms=1)
+
+class DummyVS:
+    def __init__(self, docs_by_query):
+        self.docs_by_query = docs_by_query
+    def as_retriever(self, search_kwargs=None):
+        class R:
+            def __init__(self, outer): self.outer = outer
+            def invoke(self, q):
+                # vrati listu dokumenta po upitu q
+                return [Document(page_content=t, metadata={"source": f"s-{i}"}) for i, t in enumerate(self.outer.docs_by_query.get(q, []))]
+        return R(self)
+
+@pytest.fixture(autouse=True)
+def patch_make_chat(monkeypatch):
+    # prvi poziv (translation) -> vraća englesku verziju,
+    # drugi poziv (multi-query) -> vrati 3 retka s alternativama,
+    # treći (sinteza) -> bilo što, nije bitno (odgovor)
+    chat = DummyChat(["who is the ceo of openai", "CEO of OpenAI\nOpenAI chief executive\nLeadership of OpenAI", "final"])
+    monkeypatch.setattr(adv, "make_chat", lambda: chat)
+    yield
+
+@pytest.fixture(autouse=True)
+def patch_vectorstore(monkeypatch):
+    # mapiraj tri upita na razlicite dokumente
+    docs_by_query = {
+        "who is the ceo of openai": ["Q1 doc A", "Q1 doc B"],
+        "CEO of OpenAI": ["Q2 doc A"],
+        "OpenAI chief executive": ["Q3 doc A", "Q3 doc B"],
+        "Leadership of OpenAI": ["Q4 doc A"]
+    }
+    vs = DummyVS(docs_by_query)
+    monkeypatch.setattr(adv, "get_or_create_vectorstore", lambda *a, **k: vs)
+    yield
+
+def test_translate_guard(monkeypatch):
+    # force False -> ne prevodi!!
+    qt, meta = adv.translate_query_if_needed("ko je CEO OpenAI?", force=False)
+    assert qt == "ko je CEO OpenAI?"
+    assert meta["translated"] is False
+
+def test_multi_query_generation(monkeypatch):
+    qs, m = adv.generate_multi_queries("seed", n=3)
+    assert len(qs) >= 1 
+    assert m.get("provider") == "mock"
+
+def test_rrf_fusion_scores():
+    d1 = [Document(page_content="A"), Document(page_content="B")]
+    d2 = [Document(page_content="B"), Document(page_content="C")]
+    fused = adv.reciprocal_rank_fusion([d1, d2], k_smooth=60)
+    # očekujemo da "B" bude visoko jer se pojavljuje u obje liste
+    texts = [d.page_content for d, _ in fused[:3]]
+    assert "B" in texts
+
+def test_answer_advanced_fusion():
+    res = adv.answer_advanced("ko je CEO OpenAI?", k=3, translate=True, mode="fusion", n_queries=3)
+    assert isinstance(res.answer, str)
+    assert len(res.docs) <= 3
+    assert res.meta["mode"] == "fusion"

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,5 +1,5 @@
+# tests/test_smoke.py
 import httpx, pytest
-
 BASE = "http://localhost:8000"
 
 @pytest.mark.timeout(10)
@@ -11,5 +11,5 @@ def test_health():
 def test_collections():
     r = httpx.get(f"{BASE}/collections", timeout=5)
     assert r.status_code == 200
-    assert isinstance(r.json(), list)
-
+    data = r.json()
+    assert isinstance(data["collections"], list)


### PR DESCRIPTION
## Sažetak
Ovaj PR uvodi **Advanced RAG** pipeline:
- **Query Translation** (auto/force) — za bolji retrieval kad embedder nije multilingual,
- **Multi-Query** — generiranje više semantički različitih upita,
- **RAG-Fusion (RRF)** — spajanje rangova iz više lista rezultata.

Uz to: integracija u API, Docker compose (Ollama + Qdrant), testovi i ažuriran README s točnim pipelineom i cURL primjerima.

---

## Što je novo
- `app/rag_advanced.py` — implementacija translation + multi-query + RRF fusion.
- `app/api.py` — endpoint `/query` podržava `mode` (`simple|multi|fusion`), `n_queries`, `translate`.
- `app/llm.py` — adapteri za OpenAI/Ollama (`LLM_TIMEOUT`, `OLLAMA_BASE_URL` iz `.env`).
- `app/config.py` — napredne postavke (`enable_*`, `multi_query_n`, `rrf_k_smooth`).
- `app/vectorstore.py` — Qdrant inicijalizacija i helperi.
- `app/main.py` — startup čekanje Qdrant-a, warm-up embeddinga.
- `README.md` — novi dio o Advanced RAG + točan terminal pipeline.
- Testovi:
  - `tests/test_api_smoke.py` — API smoke (baseline i advanced call),
  - `tests/test_rag_advanced_unit.py` — unit testovi za translate/multi/fusion,
  - `tests/test_smoke.py` — e2e health/collections (po potrebi).
- Docker:
  - `docker-compose.yml` — servisi `qdrant`, `ollama`, `ollama-init`, `api`.
  - `Dockerfile` — CPU PyTorch, requirements, uvicorn entry.

